### PR TITLE
Switched to `Binary::asBinary`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "php": ">=8.1",
     "ext-mbstring": "*",
     "ext-sodium": "*",
-    "petrknap/binary": "^4.0",
+    "petrknap/binary": "^4.1",
     "petrknap/shorts": "^2.1"
   },
   "require-dev": {

--- a/src/CryptoSodiumTrait.php
+++ b/src/CryptoSodiumTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PetrKnap\CryptoSodium;
 
 use InvalidArgumentException;
+use PetrKnap\Binary\Binary;
 use SensitiveParameter;
 use Throwable;
 
@@ -74,7 +75,7 @@ trait CryptoSodiumTrait
         } catch (Exception\CouldNotDecryptData $exception) {
             throw $exception;
         } catch (Throwable $reason) {
-            throw new Exception\CouldNotDecryptData(__METHOD__, (string) $ciphertext, $reason);
+            throw new Exception\CouldNotDecryptData(__METHOD__, Binary::asBinary($ciphertext), $reason);
         }
     }
 
@@ -101,7 +102,7 @@ trait CryptoSodiumTrait
         } catch (Exception\CouldNotEncryptData $exception) {
             throw $exception;
         } catch (Throwable $reason) {
-            throw new Exception\CouldNotEncryptData(__METHOD__, (string) $message, $reason);
+            throw new Exception\CouldNotEncryptData(__METHOD__, Binary::asBinary($message), $reason);
         }
     }
 

--- a/src/SecretStream/XChaCha20Poly1305.php
+++ b/src/SecretStream/XChaCha20Poly1305.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PetrKnap\CryptoSodium\SecretStream;
 
+use PetrKnap\Binary\Binary;
 use PetrKnap\CryptoSodium\CryptoSodiumInterface;
 use PetrKnap\CryptoSodium\CryptoSodiumTrait;
 use PetrKnap\CryptoSodium\DataEraser;
@@ -91,7 +92,7 @@ class XChaCha20Poly1305 implements KeyGenerator, DataEraser
                 state: $state,
                 aBytes: SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES,
             );
-        }, (string) $header);
+        }, Binary::asBinary($header));
     }
 
     /**


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> What is more readable, `$binaryData = (string) $data;` or `$binaryData = Binary::asBinary($data);`?
>
> The second one, `$binaryData = Binary::asBinary($data);`, is more readable. It's clear that you're explicitly converting `$data` to a binary format, whereas the first one uses a type cast, which can be less intuitive. Readability and clarity often win the day when you're coding!
