### PR TITLE
Renamed internal `CiphertextWithNonce` method `fromString` to `fromBinary`

### DIFF
--- a/src/CiphertextWithNonce.php
+++ b/src/CiphertextWithNonce.php
@@ -21,7 +21,7 @@ final class CiphertextWithNonce implements BinariableInterface
     /**
      * @internal there is no reason to call it from the outside
      */
-    public static function fromString(string $ciphertext, int $nonceBytes): self
+    public static function fromBinary(string $ciphertext, int $nonceBytes): self
     {
         [$nonce, $ciphertext] = (new Byter())->bite($ciphertext, $nonceBytes);
         return new self(

--- a/src/CryptoSodiumTrait.php
+++ b/src/CryptoSodiumTrait.php
@@ -63,7 +63,7 @@ trait CryptoSodiumTrait
                 );
             } else {
                 if (is_string($ciphertext)) {
-                    $ciphertextWithNonce = CiphertextWithNonce::fromString(
+                    $ciphertextWithNonce = CiphertextWithNonce::fromBinary(
                         ciphertext: $ciphertext,
                         nonceBytes: $nonceBytes,
                     );


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.

