### PR TITLE
Implemented `Sign` (detached mode)

### DIFF
--- a/src/CryptoSodiumInterface.php
+++ b/src/CryptoSodiumInterface.php
@@ -81,6 +81,15 @@ interface CryptoSodiumInterface
     ): string; // @todo return SignedMessage
 
     /**
+     * @throws Exception\CouldNotSignData
+     */
+    public function signDetached(
+        string $message,
+        #[SensitiveParameter]
+        string &$_,
+    ): string; // @todo return Signature
+
+    /**
      * @throws Exception\CouldNotVerifyData
      */
     public function verified(
@@ -88,4 +97,11 @@ interface CryptoSodiumInterface
         #[SensitiveParameter]
         string &$_,
     ): string;
+
+    public function verifyDetached(
+        string $signature,
+        string $message,
+        #[SensitiveParameter]
+        string &$_,
+    ): bool;
 }

--- a/src/Sign.php
+++ b/src/Sign.php
@@ -25,7 +25,9 @@ use Throwable;
                 'sodium_crypto_sign_secretkey',
                 'sodium_crypto_sign_publickey',
                 'sodium_crypto_sign',
+                'sodium_crypto_sign_detached',
                 'sodium_crypto_sign_open',
+                'sodium_crypto_sign_verify_detached',
             ],
         );
     }
@@ -90,6 +92,25 @@ use Throwable;
     }
 
     /**
+     * @param non-empty-string $secretKey
+     *
+     * @return non-empty-string signature
+     *
+     * @throws Exception\CouldNotSignData
+     */
+    public function signDetached(
+        string $message,
+        #[SensitiveParameter]
+        string &$secretKey,
+    ): string {
+        try {
+            return sodium_crypto_sign_detached($message, $secretKey);
+        } catch (Throwable $reason) {
+            throw new Exception\CouldNotSignData(__METHOD__, $message, $reason);
+        }
+    }
+
+    /**
      * @param non-empty-string $signedMessage
      * @param non-empty-string $publicKey
      *
@@ -112,6 +133,23 @@ use Throwable;
             throw $exception;
         } catch (Throwable $reason) {
             throw new Exception\CouldNotVerifyData(__METHOD__, $signedMessage, $reason);
+        }
+    }
+
+    /**
+     * @param non-empty-string $signature
+     * @param non-empty-string $publicKey
+     */
+    public function verifyDetached(
+        string $signature,
+        string $message,
+        #[SensitiveParameter]
+        string &$publicKey,
+    ): bool {
+        try {
+            return sodium_crypto_sign_verify_detached($signature, $message, $publicKey);
+        } catch (Throwable) {
+            return false;
         }
     }
 }

--- a/tests/CryptoSodiumTestCase.php
+++ b/tests/CryptoSodiumTestCase.php
@@ -18,7 +18,7 @@ abstract class CryptoSodiumTestCase extends TestCase
     protected string $encrypted;
     protected string $decryptMethodName = 'decrypt';
     protected array $decryptArgsSet = [];
-    protected string $decrypted;
+    protected string|bool $decrypted;
     protected array $pushArgsSet = [];
 
     protected function setUp(): void

--- a/tests/SignInDetachedModeTest.php
+++ b/tests/SignInDetachedModeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\CryptoSodium;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Sign::class)]
+final class SignInDetachedModeTest extends SignTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->encryptMethodName = 'signDetached';
+        $this->encryptArgsSet = [
+            [self::MESSAGE, $this->secretKey],
+        ];
+        $this->encrypted = base64_decode(self::B64_SIGNATURE);
+
+        $this->decryptMethodName = 'verifyDetached';
+        $this->decryptArgsSet = [
+            [$this->encrypted, self::MESSAGE, $this->publicKey],
+        ];
+        $this->decrypted = true;
+    }
+}


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> interface Sign {
>>     /**
>>      * @throws Exception\CouldNotSignData
>>      */
>>     public function signDetached(
>>         string $message,
>>         #[SensitiveParameter]
>>         string &$secretKey,
>>     ): string;
>> 
>>     public function verifyDetached(
>>         string $signature,
>>         string $message,
>>         #[SensitiveParameter]
>>         string &$publicKey,
>>     ): bool;
>> }
>> ```
>
> Certainly! This code defines a PHP interface named `Sign`, which outlines two methods related to cryptographic signing and verification:
> 1. **`signDetached` Method:**
>    - Accepts a `message` and a `secretKey` (marked as sensitive).
>    - Returns a cryptographic signature for the message.
>    - May throw an exception (`CouldNotSignData`) if signing fails.
> 2. **`verifyDetached` Method:**
>    - Takes a `signature`, a `message`, and a `publicKey` (marked as sensitive).
>    - Returns `true` if the signature is valid for the given message and public key; otherwise, `false`.
>
> This interface ensures that any implementing class provides functionality for securely signing data and verifying signatures using asymmetric cryptographic principles. Want to dive deeper into implementation details? Let me know!
>
>> Is there way to design the interface better?
>
> Absolutely! A few refinements can make the interface more robust and flexible. Here are some areas to improve:
>
> **Potential Enhancements**
> 1. **Error Handling with Dedicated Exceptions**
>    - Instead of a single `CouldNotSignData` exception, consider creating more granular exceptions for different failure cases.
>    - Example: `SignatureGenerationException`, `KeyInvalidException`, etc.
> 2. **Support for Multiple Algorithms**
>    - Allow specifying the hashing or signing algorithm.
>    - Example: `signDetached(string $message, string &$secretKey, string $algorithm): string;`
> 3. **Immutable Key Representation**
>    - Instead of passing keys as mutable string &$secretKey, use dedicated key objects like `PrivateKey` and `PublicKey` classes to encapsulate key management securely.
> 4. **Returning More Structured Data**
>    - Instead of returning a raw `string` signature, provide a `SignedMessage` class that includes metadata, timestamp, or additional verification details.
>
>> What about method names, are there better alternatives?
> 
> Absolutely! Method names should be clear, intuitive, and convey their purpose effectively. Your current names, `signDetached` and `verifyDetached`, describe their functionality, but they could be improved for readability and ease of understanding.
>
> **Alternative Method Names**
> 
> Here are some refined alternatives:
> - `generateSignature` instead of `signDetached` – more intuitive and implies signature creation.
> - `validateSignature` instead of `verifyDetached` – avoids ambiguity and reinforces verification.
>
> **Why This Change?**
> 
> ✔ Self-Explanatory – The names naturally indicate the action performed.
>
> ✔ Avoids Jargon – "Detached" might be unnecessary unless there's a specific cryptographic reason for it.
>
> ✔ Consistency – "Generate" and "Validate" as action words create uniformity.
>
> Do you prefer more explicit method names, or do you lean toward brevity?